### PR TITLE
Update download link for mk2-cockpit-internals

### DIFF
--- a/lib/kosmos/packages/mk2_cockpit_interior.rb
+++ b/lib/kosmos/packages/mk2_cockpit_interior.rb
@@ -1,6 +1,6 @@
 class Mk2CockpitInterior < Kosmos::Package
   title 'Mk2 Cockpit Interior'
-  url 'http://kerbalspaceport.com/wp/wp-content/themes/kerbal/inc/download.php?f=uploads/2013/12/SH-MK2Cockpit.zip'
+  url 'http://kerbal.curseforge.com/ksp-mods/220927-mk2-cockpit-internals'
 
   def install
     merge_directory 'GameData'


### PR DESCRIPTION
Spaceport is no more, Mk2 Cockpit internals is now hosted on Curse
