### PR TITLE
add support for direct dropbox links

### DIFF
--- a/lib/kosmos/download_url.rb
+++ b/lib/kosmos/download_url.rb
@@ -43,7 +43,12 @@ module Kosmos
     end
 
     def extract_dropbox_url
-      rendered_page.css('#default_content_download_button').first['href']
+      button = rendered_page.css('#default_content_download_button')
+      if button.first
+        button.first['href']
+      else
+        url
+      end
     end
 
     def extract_curseforge_url


### PR DESCRIPTION
This add support for links that directly trigger the download from dropbox instead of showing a download button.

i.e. https://dl.dropboxusercontent.com/u/103148235/ImprovedChaseCamerav1.3.1.zip

(No idea if I'm doing this right, I have no clue how to ruby)
