### PR TITLE
supress error messages from git

### DIFF
--- a/lib/kosmos/git_adapter.rb
+++ b/lib/kosmos/git_adapter.rb
@@ -17,8 +17,8 @@ module Kosmos
 
       def commit_everything(repo_path, commit_message)
         Dir.chdir(repo_path) do
-          `git add -A -f`
-          `git commit --allow-empty -m #{commit_message.shellescape}`
+          `git add -A -f 2>&1`
+          `git commit --allow-empty -m #{commit_message.shellescape} 2>&1`
         end
       end
 
@@ -26,7 +26,7 @@ module Kosmos
         Dir.chdir(repo_path) do
           # Favor "ours" (which is always HEAD for our purposes) when git-revert
           # can handle that on its own.
-          `git revert --no-commit --strategy=merge --strategy-option=ours #{commit.sha}`
+          `git revert --no-commit --strategy=merge --strategy-option=ours #{commit.sha} 2>&1`
 
           # When files are being created or deleted, git will not do anything.
           # In this case, keep all files alive; better to accidentally pollute


### PR DESCRIPTION
Prevents error messages like 

```
warning: CRLF will be replaced by LF in Ships/SPH/FAR Jet Airliner.craft.
The file will have its original line endings in your working directory.
```

from being spanned in the console during git operations
