### PR TITLE
set git to ingore line feeds

### DIFF
--- a/lib/kosmos/git_adapter.rb
+++ b/lib/kosmos/git_adapter.rb
@@ -8,6 +8,7 @@ module Kosmos
           `git init`
           `git config user.name Kosmos`
           `git config user.email kosmos@kosmos.kosmos`
+          `git config core.autocrlf false`
 
           File.open('.gitignore', 'w') do |file|
             file.write "!*\n"


### PR DESCRIPTION
Prevents error messages like

```
warning: CRLF will be replaced by LF in Ships/SPH/FAR Jet Airliner.craft.
The file will have its original line endings in your working directory.
```

from being spanned in the console during git operations
