### PR TITLE
add the options for packages to remove file or folders in their install scripts

### DIFF
--- a/lib/kosmos/package_dsl.rb
+++ b/lib/kosmos/package_dsl.rb
@@ -6,5 +6,9 @@ module Kosmos
       FileUtils.cp_r(File.join(@download_dir, from),
         File.join(@ksp_path, destination))
     end
+    
+    def remove(path, opts = {})
+      FileUtils.rm_rf(File.join(@ksp_path, path))
+    end
   end
 end


### PR DESCRIPTION
I came across the need to remove files or folders during installation due to a mod including the `.git` directory in the distributed zip.

Having the `.git` folder in the GameData confuses git and breaks the uninstall command since git tries to handle it as a submodule
