### PR TITLE
Put commit messages in quotes.

### DIFF
--- a/lib/kosmos/git_adapter.rb
+++ b/lib/kosmos/git_adapter.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 module Kosmos
   module GitAdapter
     class << self
@@ -19,7 +17,7 @@ module Kosmos
       def commit_everything(repo_path, commit_message)
         Dir.chdir(repo_path) do
           `git add -A -f`
-          `git commit --allow-empty -m #{commit_message.shellescape}`
+          `git commit --allow-empty -m "#{commit_message}"`
         end
       end
 


### PR DESCRIPTION
The previous approach was kind of a hack, and only worked on Unix.

Closes #297 .
