### PR TITLE
Don't pass Windows paths to Dir#glob.

### DIFF
--- a/lib/kosmos/post_processors/module_manager_resolver.rb
+++ b/lib/kosmos/post_processors/module_manager_resolver.rb
@@ -2,10 +2,10 @@ module Kosmos
   module PostProcessors
     class ModuleManagerResolver
       def self.post_process(ksp_path)
-        game_data = File.join(ksp_path, 'GameData')
-
-        module_managers = Dir[File.join(game_data, '*')].select do |file|
-          File.basename(file).start_with?('ModuleManager')
+        module_managers = Dir.chdir(ksp_path) do
+          Dir["GameData/*"].select do |file|
+            File.basename(file).start_with?('ModuleManager')
+          end
         end
 
         most_recent_manager = module_managers.max_by do |file|
@@ -20,9 +20,11 @@ module Kosmos
         end
 
         (module_managers - [most_recent_manager]).each do |file|
-          Util.log "Detected and deleting outdated version of ModuleManager: #{file}"
+          file_name = File.basename(file)
+          Util.log "Detected and deleting outdated version of ModuleManager: " +
+              "#{file_name}"
 
-          File.delete(file)
+          File.delete(File.join(ksp_path, file))
         end
       end
     end


### PR DESCRIPTION
Instead of using File.join, a Dir.chdir followed by a Dir#glob can do the same
thing on Unix and will avoid there ever being backslash-separated paths being
passed to Dir#glob (aliased as Dir#[]).

Closes #347 .
