### PR TITLE
Ensure there is something to copy the origin to

### DIFF
--- a/lib/kmc/package_dsl.rb
+++ b/lib/kmc/package_dsl.rb
@@ -3,7 +3,7 @@ module Kmc
     def merge_directory(from, opts = {})
       destination = opts[:into] || '.'
 
-      FileUtils.mkdir_p(File.dirname(File.join(self.class.ksp_path, filepath)))
+      FileUtils.mkdir_p(File.dirname(File.join(self.class.ksp_path, destination)))
       FileUtils.cp_r(File.join(self.class.download_dir, from),
         File.join(self.class.ksp_path, destination))
     end


### PR DESCRIPTION
Assuming `from` is a file needing to be copied into a hierarchy, only `cp_r` will not create the necessary directory structure. By joining the destination path, taking that `dirname`, and `mkdir_p`'ing that, we can ensure the directory where `from` needs to go will always exist. At the same time, this avoids naively creating a directory `destination` which would break desired behavior of `cp_r` by copying one level too deep at the destination.
