### PR TITLE
Ensure the destination path exists

### DIFF
--- a/lib/kmc/package_dsl.rb
+++ b/lib/kmc/package_dsl.rb
@@ -3,6 +3,7 @@ module Kmc
     def merge_directory(from, opts = {})
       destination = opts[:into] || '.'
 
+      FileUtils.mkdir_p(File.join(self.class.ksp_path, destination))
       FileUtils.cp_r(File.join(self.class.download_dir, from),
         File.join(self.class.ksp_path, destination))
     end


### PR DESCRIPTION
Based on the discussion at https://github.com/kmc/kmc/pull/426, we will assume `destination` is a directory for the origin to be copied into, as the method signature implies.
